### PR TITLE
Add optional input for specifying lifecycle hook names

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_drain_asg_names"></a> [drain\_asg\_names](#input\_drain\_asg\_names) | Name of Auto Scaling Group that the lambda function reacts. If you don't specify this, the lambda function will react to all of Auto Scaling Group in the account. You can use the comparison operators available in EventBridge. | `list(any)` | `[]` | no |
-| <a name="lifecycle_hook_names"></a> [lifecycle\_hook\_names](#input\_lifecycle\hook\_names) | List of lifecycle hooks for which to trigger Lambda. If you don't specify this, the lambda function will react to all instance termination lifecycle events. | `list(string)` | `[]` | no |
+| <a name="input_lifecycle_hook_names"></a> [lifecycle\_hook\_names](#input\_lifecycle\hook\_names) | List of lifecycle hooks for which to trigger Lambda. If you don't specify this, the lambda function will react to all instance termination lifecycle events. | `list(string)` | `[]` | no |
 | <a name="input_event_main_version"></a> [event\_main\_version](#input\_event\_main\_version) | The version of the Lambda function that receivets the events | `string` | `"$LATEST"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | A prefix used for the resources created by this module | `string` | n/a | yes |
 | <a name="input_source_version"></a> [source\_version](#input\_source\_version) | A version of the upstream release | `string` | `"1.0.7"` | no |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_drain_asg_names"></a> [drain\_asg\_names](#input\_drain\_asg\_names) | Name of Auto Scaling Group that the lambda function reacts. If you don't specify this, the lambda function will react to all of Auto Scaling Group in the account. You can use the comparison operators available in EventBridge. | `list(any)` | `[]` | no |
-| <a name="input_lifecycle_hook_names"></a> [lifecycle\_hook\_names](#input\_lifecycle\hook\_names) | List of lifecycle hooks for which to trigger Lambda. If you don't specify this, the lambda function will react to all instance termination lifecycle events. | `list(string)` | `[]` | no |
+| <a name="input_lifecycle_hook_names"></a> [lifecycle\_hook\_names](#input\_lifecycle\_hook\_names) | List of lifecycle hooks for which to trigger Lambda. If you don't specify this, the lambda function will react to all instance termination lifecycle events. | `list(string)` | `[]` | no |
 | <a name="input_event_main_version"></a> [event\_main\_version](#input\_event\_main\_version) | The version of the Lambda function that receivets the events | `string` | `"$LATEST"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | A prefix used for the resources created by this module | `string` | n/a | yes |
 | <a name="input_source_version"></a> [source\_version](#input\_source\_version) | A version of the upstream release | `string` | `"1.0.7"` | no |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_drain_asg_names"></a> [drain\_asg\_names](#input\_drain\_asg\_names) | Name of Auto Scaling Group that the lambda function reacts. If you don't specify this, the lambda function will react to all of Auto Scaling Group in the account. You can use the comparison operators available in EventBridge. | `list(any)` | `[]` | no |
+| <a name="lifecycle_hook_names"></a> [lifecycle\_hook\_names](#input\_lifecycle\hook\_names) | List of lifecycle hooks for which to trigger Lambda. If you don't specify this, the lambda function will react to all instance termination lifecycle events. | `list(string)` | `[]` | no |
 | <a name="input_event_main_version"></a> [event\_main\_version](#input\_event\_main\_version) | The version of the Lambda function that receivets the events | `string` | `"$LATEST"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | A prefix used for the resources created by this module | `string` | n/a | yes |
 | <a name="input_source_version"></a> [source\_version](#input\_source\_version) | A version of the upstream release | `string` | `"1.0.7"` | no |

--- a/main.tf
+++ b/main.tf
@@ -127,9 +127,14 @@ resource "aws_cloudwatch_event_rule" "specific" {
       "EC2 Instance-terminate Lifecycle Action"
     ],
     source = ["aws.autoscaling"]
-    detail = {
-      AutoScalingGroupName = var.drain_asg_names
-    }
+    detail = merge(
+      {
+        AutoScalingGroupName = var.drain_asg_names
+      },
+      length(var.lifecycle_hook_names) > 0 ? {
+        LifecycleHookName = var.lifecycle_hook_names
+      } : {}
+    )
   })
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "drain_asg_names" {
   default     = []
 }
 
+variable "lifecycle_hook_names" {
+  type        = list(string)
+  description = "List of lifecycle hooks for which to trigger Lambda. If you don't specify this, the lambda function will react to all instance termination lifecycle events."
+  default     = []
+}
+
 variable "source_version" {
   type        = string
   description = "A version of the upstream release"


### PR DESCRIPTION
## Overview

While experimenting with the ECS managed draining, I discovered that this lambda function can conflict with the ECS managed draining if events meant for ECS draining are processed by this lambda function.

The conflict between custom hooks and the `ecs-managed-draining-termination-hook` seems to result in some instances not draining properly and killing any running tasks.

```
Instance "i-instance-id" already terminated2025/03/03 03:41:25 
{
    "errorMessage": "ValidationError: No active Lifecycle Action found with token 09ae4eec-33c3-4a70-b646-bf78be315e19\n\tstatus code: 400, request id: 818f3065-7dd2-4d67-a6f5-9487d95d4d54",
    "errorType": "requestError"
}
```

This PR adds an input variable for specifying the lifecycle hook names which will trigger the lambda to drain instances so we can be more specific on the events we react to.